### PR TITLE
Bug no alerts

### DIFF
--- a/Umbrella Today?.xcodeproj/project.pbxproj
+++ b/Umbrella Today?.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		55C92A9523BC0B950040F854 /* HourlyForecastViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55C92A9423BC0B950040F854 /* HourlyForecastViewController.swift */; };
 		55CC3E8A23BFC30B001A38C1 /* UserInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CC3E8923BFC30B001A38C1 /* UserInfoViewController.swift */; };
 		55CC3E8C23BFD425001A38C1 /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CC3E8B23BFD425001A38C1 /* FirebaseManager.swift */; };
+		55DCE75B23C2C6B300B1B39C /* SceneDelegateObservables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DCE75A23C2C6B300B1B39C /* SceneDelegateObservables.swift */; };
 		740AA9BC6AFAFF17F1BCBC0D /* Pods_Umbrella_Today_.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FAFD893038799641174FC52B /* Pods_Umbrella_Today_.framework */; };
 /* End PBXBuildFile section */
 
@@ -104,6 +105,7 @@
 		55C92A9423BC0B950040F854 /* HourlyForecastViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HourlyForecastViewController.swift; sourceTree = "<group>"; };
 		55CC3E8923BFC30B001A38C1 /* UserInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoViewController.swift; sourceTree = "<group>"; };
 		55CC3E8B23BFD425001A38C1 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
+		55DCE75A23C2C6B300B1B39C /* SceneDelegateObservables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegateObservables.swift; sourceTree = "<group>"; };
 		99EC326CFE3E1ADBC87A6EF7 /* Pods-Umbrella Today?.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Umbrella Today?.release.xcconfig"; path = "Target Support Files/Pods-Umbrella Today?/Pods-Umbrella Today?.release.xcconfig"; sourceTree = "<group>"; };
 		FAFD893038799641174FC52B /* Pods_Umbrella_Today_.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Umbrella_Today_.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -181,6 +183,7 @@
 				5585762E23B87E3E00CABA38 /* Range.swift */,
 				555A1A5823BE7DBD00953214 /* DayOfWeek.swift */,
 				551A0FAB23C02F2300F4E5F1 /* Constants.swift */,
+				55DCE75A23C2C6B300B1B39C /* SceneDelegateObservables.swift */,
 				555A1A5623BE3A9400953214 /* cities.us.fromAPI.json */,
 				55A079AD23BD2D65002BD11D /* city.list.withoutUS.json */,
 				5585762A23B8794000CABA38 /* IndexesOfAlphabeticalCheckPointsInCityList.txt */,
@@ -439,6 +442,7 @@
 				55A079AA23BD1C39002BD11D /* AutocompleteCitySearchTableViewCell.swift in Sources */,
 				555A1A5923BE7DBD00953214 /* DayOfWeek.swift in Sources */,
 				551CF19A23BB039A00101E57 /* FiveDayForecastViewController.swift in Sources */,
+				55DCE75B23C2C6B300B1B39C /* SceneDelegateObservables.swift in Sources */,
 				55C3FE4723B6B27F00CE7776 /* Umbrella_Today_.xcdatamodeld in Sources */,
 				551BFA7823BF000D00E98456 /* SignUpViewController.swift in Sources */,
 				5585763123B87E5700CABA38 /* Temperature.swift in Sources */,

--- a/Umbrella Today?.xcworkspace/xcuserdata/brandonfong.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Umbrella Today?.xcworkspace/xcuserdata/brandonfong.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -132,5 +132,21 @@
             landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "E1CBA9E4-E233-4962-8CB0-7011263AABA9"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Umbrella Today?/Controller/View Controllers/ScrollParentViewController.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "155"
+            endingLineNumber = "155"
+            landmarkName = "checkLocationAuthorization()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
    </Breakpoints>
 </Bucket>

--- a/Umbrella Today?.xcworkspace/xcuserdata/brandonfong.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Umbrella Today?.xcworkspace/xcuserdata/brandonfong.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -132,21 +132,5 @@
             landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "E1CBA9E4-E233-4962-8CB0-7011263AABA9"
-            shouldBeEnabled = "Yes"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "Umbrella Today?/Controller/View Controllers/ScrollParentViewController.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "155"
-            endingLineNumber = "155"
-            landmarkName = "checkLocationAuthorization()"
-            landmarkType = "7">
-         </BreakpointContent>
-      </BreakpointProxy>
    </Breakpoints>
 </Bucket>

--- a/Umbrella Today?/Controller/View Controllers/ScrollParentViewController.swift
+++ b/Umbrella Today?/Controller/View Controllers/ScrollParentViewController.swift
@@ -41,13 +41,23 @@ class ScrollParentViewController: UIViewController {
     // MARK: - View Controller Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(true)
+        print("view did appear")
         addWhiteLayer()
+        // had to move this here because the alerts wouldn't be able to be presented if the view wasn't in the window hierarchy yet
         checkLocationServices()
     }
 }
 
 // MARK: - Setup Pages
 extension ScrollParentViewController {
+    @objc func navigateToLocationServicesSettings() {
+        UIApplication.shared.open(URL(string:UIApplication.openSettingsURLString)!)
+    }
+    
     func setupPages() {
         scrollView.isPagingEnabled = true
         scrollView.showsHorizontalScrollIndicator = false
@@ -154,7 +164,9 @@ extension ScrollParentViewController: CLLocationManagerDelegate {
             print("location services are denied")
             let alert = UIAlertController(title: "Location Permissions Denied", message: "Please enable location services in your device's settings.", preferredStyle: .alert)
 //            alerts are not showing up becacuse scroll view apparently is not in window hierarchy
-            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { (action) in
+                self.navigateToLocationServicesSettings()
+            }))
             self.present(alert, animated: true, completion: nil)
         case .notDetermined:
             locationManager.requestWhenInUseAuthorization()

--- a/Umbrella Today?/Model/SceneDelegateObservables.swift
+++ b/Umbrella Today?/Model/SceneDelegateObservables.swift
@@ -1,0 +1,15 @@
+//
+//  SceneDelegateObservables.swift
+//  Umbrella Today?
+//
+//  Created by Brandon Fong on 1/5/20.
+//  Copyright © 2020 Fiesta Togo Inc. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+class SceneDelegateObservables {
+    static var sceneDidBecomeActive = BehaviorRelay<Bool>(value: true)
+}

--- a/Umbrella Today?/SceneDelegate.swift
+++ b/Umbrella Today?/SceneDelegate.swift
@@ -12,8 +12,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        print("scene will connect to session")
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
@@ -21,6 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
+        print("scene did disconnect")
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.
         // Release any resources associated with this scene that can be re-created the next time the scene connects.
@@ -28,21 +29,27 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
+        print("scene did become active")
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+        
+        // need to tell scroll view to check location services and refire everything if anythign is different
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
+        print("scene will resign active")
         // Called when the scene will move from an active state to an inactive state.
         // This may occur due to temporary interruptions (ex. an incoming phone call).
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
+        print("scene will enter foreground")
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
+        print("scene did enter background")
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.

--- a/Umbrella Today?/SceneDelegate.swift
+++ b/Umbrella Today?/SceneDelegate.swift
@@ -11,9 +11,9 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        print("scene will connect to session")
+//        print("scene will connect to session")
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
@@ -21,7 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
-        print("scene did disconnect")
+//        print("scene did disconnect")
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.
         // Release any resources associated with this scene that can be re-created the next time the scene connects.
@@ -29,27 +29,28 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
-        print("scene did become active")
+//        print("scene did become active")
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
         
         // need to tell scroll view to check location services and refire everything if anythign is different
+        SceneDelegateObservables.sceneDidBecomeActive.accept(true)
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
-        print("scene will resign active")
+//        print("scene will resign active")
         // Called when the scene will move from an active state to an inactive state.
         // This may occur due to temporary interruptions (ex. an incoming phone call).
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
-        print("scene will enter foreground")
+//        print("scene will enter foreground")
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
-        print("scene did enter background")
+//        print("scene did enter background")
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.


### PR DESCRIPTION
Alerts weren't showing up because the code to instantiate them was in viewDidLoad of scroll parent VC and the scroll parent VC wasn't even added to window hierarchy yet. 
- Uses RxSwift listener for when scene becomes active.
- uses that to tell scroll parent VC when it's time to check location services and fire the API
- if the user's location is denied, it will send an alert and navigate user to settings,
- once user comes back, listener will fire that scene became active, and then check location again.

